### PR TITLE
Fix bug introduced by 1272129

### DIFF
--- a/client.go
+++ b/client.go
@@ -274,7 +274,10 @@ func (c *Client) checkToken(response *Response) (retry bool, err error) {
 		}
 		_, err = c.RefreshToken()
 	}
-	return retry, errors.New("Invalid/Expired Marketo Auth Token")
+	if err != nil {
+		return retry, errors.New("Invalid/Expired Marketo Auth Token")
+	}
+	return retry, nil
 }
 
 // Get performs an HTTP GET for the specified resource url


### PR DESCRIPTION
Check Token will have returned an error when there was none via nil variable `err` declared by return type of method signature.